### PR TITLE
fix(clipboard): Fix the issue of normal prompt text not being copied correctly

### DIFF
--- a/apps/electron-frontend/src/components/workflow-editor/reactflow-clipboard.ts
+++ b/apps/electron-frontend/src/components/workflow-editor/reactflow-clipboard.ts
@@ -10,6 +10,10 @@ export type EditorClipBoardData = {
 
 const CLIPBOARD_TYPE = '@comflowy/nodes';
 export function copyNodes(nodes: PersistedWorkflowNode[], ev: ClipboardEvent) {
+  if (nodes.length === 0) {
+    // Normal prompt text copying
+    return;
+  } 
   const clipboardData = JSON.stringify({
     nodes,
   });


### PR DESCRIPTION
if user copies prompt from node, normal prompt text not being copied correctly