### PR TITLE
fix error handler message tip not display problem

### DIFF
--- a/apps/electron-frontend/src/components/workflow-editor/reactflow-model-selector/model-download-channel.tsx
+++ b/apps/electron-frontend/src/components/workflow-editor/reactflow-model-selector/model-download-channel.tsx
@@ -33,7 +33,7 @@ export function ModelDownloadChannel() {
     }
   }, []);
 
-  const onModelDownloadFailed = useCallback((payload) => {
+  const onModelDownloadFailed = useCallback(({payload}) => {
     const {error, runId} = payload;
     message.error("Model download failed, please contact us to get support." + error);
     console.log("onfailed");


### PR DESCRIPTION
Before:

![image](https://github.com/6174/comflowyspace/assets/6964737/4a33d48d-65d9-4092-8828-2450ae73171b)


After:

![image](https://github.com/6174/comflowyspace/assets/6964737/fdd94f77-d566-4ee8-a359-ae7c0c006365)

and will not block button recovery state to non edit